### PR TITLE
revert lazy loading of main page logo

### DIFF
--- a/pub/index.html
+++ b/pub/index.html
@@ -49,7 +49,7 @@
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
         </button>
-        <a href="/"><img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="img/inog.svg" class="img-responsive lozad navbar-brand"></a>
+        <a href="/"><img src="img/inog.svg" class="img-responsive navbar-brand"></a>
       </div>
       <div class="navbar-collapse collapse" id="navbar-main">
         <ul class="nav navbar-nav navbar-right">
@@ -147,7 +147,7 @@
         <div class="col-lg-6">
           <h3>iNOG::12<small> 2019.02.27</small></h3>
           <p class="h5">Do the right thing but faster!</p>
-          <p>A historic meet at <a href="https://dogpatchlabs.com/" target="_blank">DogPatch</a> coworking and event space hosted by <a href="https://cisco.com/" target="_blank">Cisco</a>! 
+          <p>A historic meet at <a href="https://dogpatchlabs.com/" target="_blank">DogPatch</a> coworking and event space hosted by <a href="https://cisco.com/" target="_blank">Cisco</a>!
           </p>
           <ul>
             <li><strong><a href="https://fit.ie" target="_blank" class="text-primary">George Ryan</a></strong> (FIT) An introduction to FIT(Fast Track into IT) programs <a href="files/iNOG12_George_FIT.pptx" target="_blank" class="text-warning"><strong>SLIDES</strong></a></li>


### PR DESCRIPTION
After opening https://inog.net a few times I noticed the top left logo appears about 2-3 seconds after the rest of the page loads, even after YT embeds.
If using umatrix/noscript it doesn't load at all, even with first-part JS enabled.

Given the svg is really tiny, I think we can load this the good ol' fashioned way to keep the top of the page looking whole and snappy.