### PR TITLE
Add bimi file for emails

### DIFF
--- a/pub/img/bimi.svg
+++ b/pub/img/bimi.svg
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.2"
+   baseProfile="tiny-ps"
+   id="svg2"
+   viewBox="0 0 708 708"
+   height="200mm"
+   width="200mm">
+  <title>iNOG</title>
+  <defs
+     id="defs4" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>iNOG</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-155.91742,260.37042)"
+     id="layer1">
+    <g
+       transform="matrix(2.4331912,0,0,2.6770984,-222.44932,-934.66577)"
+       id="text4136"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
+      <g
+         id="text4145"
+         style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
+        <path
+           id="path4164"
+           d="m 182.54828,360.22458 0,88.06641 -26.63086,0 0,-88.06641 26.63086,0 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:180px;font-family:'Aldo the Apache';-inkscape-font-specification:'Aldo the Apache';fill:#44aa00" />
+        <path
+           id="path4154"
+           d="m 182.54828,321.20114 0,31.28906 -26.63086,0 0,-31.28906 26.63086,0 z"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:180px;font-family:'Aldo the Apache';-inkscape-font-specification:'Aldo the Apache';fill:#ff6600" />
+        <path
+           id="path4156"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:180px;font-family:'Aldo the Apache';-inkscape-font-specification:'Aldo the Apache'"
+           d="m 244.68695,394.15036 0,-72.94922 25.13672,0 0,127.08985 -26.36719,0 -26.01562,-72.94922 0,72.94922 -24.96094,0 0,-127.08985 26.36719,0 25.83984,72.94922 z" />
+        <path
+           id="path4158"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:180px;font-family:'Aldo the Apache';-inkscape-font-specification:'Aldo the Apache'"
+           d="m 282.47992,321.20114 76.72852,0 0,127.08985 -76.72852,0 0,-127.08985 z m 26.71875,103.00781 23.37891,0 0,-78.83789 -23.37891,0 0,78.83789 z" />
+        <path
+           id="path4160"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:180px;font-family:'Aldo the Apache';-inkscape-font-specification:'Aldo the Apache'"
+           d="m 420.64398,424.20895 0,-19.59961 -10.81054,0 0,-22.58789 37.17773,0 0,66.26954 -75.9375,0 0,-127.08985 71.54297,0 0,24.16992 -44.82422,0 0,78.83789 22.85156,0 z" />
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
This is a brand email image of the normal inog.svg but tailored for appearing in mailboxes to highlight our email in Gmail etc.